### PR TITLE
Testing. Dockerfile run as non-root. Implicit venv

### DIFF
--- a/bdast.yaml
+++ b/bdast.yaml
@@ -19,13 +19,6 @@ include:
   - .bdast/python.yaml
   - .bdast/docker.yaml
 
-steps:
-  python_test:
-    during:
-      - +test
-    command:
-      cmd: dfbar -f ./src/Dockerfile -m test ./src
-
 actions:
 
   # Overrides for 'common' actions to perform actions

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -7,7 +7,7 @@ ARG use_image=base
 FROM python:3.13.3-slim-bullseye AS base
 
 # Work directory
-RUN mkdir -p /work && chmod 777 /work
+RUN mkdir -p /work/bin && chmod 777 /work
 WORKDIR /work
 ENV HOME=/work
 
@@ -16,13 +16,23 @@ ARG DEBIAN_FRONTEND=noninteractive
 # RUN apt-get update && apt-get install -yq --no-install-recommends sshpass
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Install any python packages
-COPY requirements.txt /work
-RUN python3 -m pip install --upgrade pip && \
-    python3 -m pip install -r /work/requirements.txt
+# Create local user account
+RUN groupadd -g 1000 -r user && \
+  useradd -u 1000 -g 1000 -d /work user
+USER 1000:1000
 
-COPY entrypoint /entrypoint
-ENTRYPOINT [ "/entrypoint" ]
+# Set up python venv
+RUN python3 -m venv /work/env && \
+    /work/env/bin/pip install --upgrade pip
+ENV PATH="/work/env/bin:/work/bin:$PATH"
+
+# Install any python packages
+COPY requirements.txt /work/
+RUN python3 -m pip install -r /work/requirements.txt && \
+    rm -f /work/requirements.txt
+
+COPY entrypoint /work/bin/entrypoint
+ENTRYPOINT [ "/work/bin/entrypoint" ]
 
 ################
 # Testing image
@@ -30,11 +40,12 @@ FROM base AS testing
 
 COPY tests /work/tests
 
-COPY tests/entrypoint /test-entrypoint
-ENTRYPOINT [ "/test-entrypoint" ]
+COPY tests/entrypoint /work/bin/test-entrypoint
+ENTRYPOINT [ "/work/bin/test-entrypoint" ]
 
 COPY tests/requirements.txt /work/test-requirements.txt
-RUN python3 -m pip install -r /work/test-requirements.txt
+RUN python3 -m pip install -r /work/test-requirements.txt && \
+    rm -f /work/test-requirements.txt
 
 ################
 # Final image

--- a/src/tests/cli/test_cli.py
+++ b/src/tests/cli/test_cli.py
@@ -1,7 +1,8 @@
 
 import sys
-import kmt
+import subprocess
 import pytest
+import kmt
 
 class TestCli:
     def test_1(self):
@@ -9,4 +10,10 @@ class TestCli:
 
         with pytest.raises(SystemExit):
             res = kmt.cli.main()
+
+    def test_2(self):
+        # Test running the entrypoint
+        ret = subprocess.call(["/work/bin/entrypoint", "--help"])
+
+        assert ret == 0
 


### PR DESCRIPTION
Use implicit container test from bdast common files
Dockerfile run kmt as non-root
Implicit activation of venv created in Dockerfile
Add test for running entrypoint
